### PR TITLE
Add Disqus comments

### DIFF
--- a/source/layouts/blog.erb
+++ b/source/layouts/blog.erb
@@ -39,6 +39,22 @@
           <div class="blog-article__content">
             <%= yield %>
           </div>
+
+          <div id="disqus_thread"></div>
+          <script type="text/javascript">
+              /* * * CONFIGURATION VARIABLES * * */
+              var disqus_shortname = 'unboxedconsulting';
+              // var disqus_identifier = '81b9f768-1dc6-466a-8a9c-fed33921e0a3'; // migration required to add this
+              var disqus_url = 'https://www.unboxedconsulting.com/blog/<%= current_page.slug %>';
+
+              /* * * DON'T EDIT BELOW THIS LINE * * */
+              (function() {
+                  var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
+                  dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
+                  (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
+              })();
+          </script>
+          <noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>
         </article>
       </div>
 


### PR DESCRIPTION
After migrating short url (ubxd.com) and HTTP URLs, Disqus comments are now associated to https://www.unboxedconsulting.com/blog/<slug>. We should start using an identifier instead of using the URL as the unique discussion identifier.

When fully migrating the blog posts we should generate these and re-import the Disqus export with this amendment. A UUID would be sufficient.
